### PR TITLE
[NSA-9317] Improve policy engine performance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,9 +27,11 @@ const verifyConfig = ({ directories, organisations, access }) => {
   verifyBlock(organisations, "organisations");
   verifyBlock(access, "access");
 };
-const deepClone = (object) => {
-  return JSON.parse(JSON.stringify(object)); // TODO: Make this more performant
-};
+
+const chunkArray = (array, size) =>
+  Array.from({ length: Math.ceil(array.length / size) }, (_, index) =>
+    array.slice(index * size, index * size + size),
+  );
 
 const getPolicies = async (clients, serviceId, correlationId) => {
   const policies = await clients.access.getPoliciesForService(
@@ -37,61 +39,6 @@ const getPolicies = async (clients, serviceId, correlationId) => {
     correlationId,
   );
   return policies || [];
-};
-const buildUserDetails = async (
-  clients,
-  userId,
-  organisationId,
-  serviceId,
-  correlationId,
-) => {
-  if (!userId) {
-    const organisation = await clients.organisations.getOrganisation(
-      organisationId,
-      correlationId,
-    );
-    return {
-      sub: "",
-      given_name: "",
-      family_name: "",
-      email: "",
-      status: -1,
-      organisation,
-      roles: [],
-    };
-  }
-
-  const user = await clients.directories.getUserById(userId, correlationId);
-  const userOrganisations = await clients.organisations.getUserOrganisations(
-    userId,
-    correlationId,
-  );
-  const userAccessToSpecifiedOrganisation = userOrganisations.find(
-    (x) => x.organisation.id.toLowerCase() === organisationId.toLowerCase(),
-  );
-  const userAccessToServiceAtOrganisation =
-    await clients.access.getUserAccessToServiceAtOrganisation(
-      userId,
-      organisationId,
-      serviceId,
-      correlationId,
-    );
-
-  const userDetails = deepClone(user);
-  userDetails.id = user.sub;
-  if (userAccessToSpecifiedOrganisation) {
-    userDetails.organisation = deepClone(
-      userAccessToSpecifiedOrganisation.organisation,
-    );
-    userDetails.organisation.role = deepClone(
-      userAccessToSpecifiedOrganisation.role,
-    );
-  }
-  userDetails.roles = userAccessToServiceAtOrganisation
-    ? userAccessToServiceAtOrganisation.roles || []
-    : [];
-
-  return userDetails;
 };
 
 const extractFieldsFromUser = (model, parentPath) => {
@@ -129,6 +76,7 @@ const extractFieldsFromUser = (model, parentPath) => {
 
   return assertionValues;
 };
+
 const isConditionFulfilled = (condition, userFields) => {
   const actual = userFields.filter((x) => x.path === condition.field);
   const matchValue = condition.operator === "is";
@@ -140,6 +88,7 @@ const isConditionFulfilled = (condition, userFields) => {
     );
   return match ? matchValue : !matchValue;
 };
+
 const applyPoliciesToUser = (user, policies, constraints) => {
   const policiesAppliedForUser = [];
   let rolesAvailableToUser = [];
@@ -188,33 +137,7 @@ const applyPoliciesToUser = (user, policies, constraints) => {
       rolesAvailableToUser.length > 0 || constraints.length === 0,
   };
 };
-const getAndApplyPoliciesToUser = async (
-  userId,
-  organisationId,
-  serviceId,
-  correlationId,
-  roles,
-  constraints,
-  clients,
-) => {
-  const policies = await getPolicies(clients, serviceId, correlationId);
-  if (policies.length === 0) {
-    return {
-      policiesAppliedForUser: [],
-      rolesAvailableToUser: roles,
-      serviceAvailableToUser: true,
-    };
-  }
 
-  const user = await buildUserDetails(
-    clients,
-    userId,
-    organisationId,
-    serviceId,
-    correlationId,
-  );
-  return applyPoliciesToUser(user, policies, constraints);
-};
 const getAndWrapConstraintsForService = async (
   serviceId,
   roles,
@@ -302,6 +225,131 @@ const getAndWrapConstraintsForService = async (
   };
 };
 
+const getServiceInformation = async (
+  serviceId,
+  clients,
+  correlationId,
+  selectedRoleIds,
+) => {
+  const [roles, policies] = await Promise.all([
+    clients.access.getRolesForService(serviceId, correlationId),
+    getPolicies(clients, serviceId, correlationId),
+  ]);
+
+  return {
+    id: serviceId,
+    roles,
+    policies,
+    constraints: await getAndWrapConstraintsForService(
+      serviceId,
+      roles,
+      correlationId,
+      clients,
+      selectedRoleIds,
+    ),
+  };
+};
+
+const getServicesInformation = async (
+  serviceIds,
+  clients,
+  correlationId,
+  selectedRoleIds,
+) => {
+  const serviceChunks = chunkArray(serviceIds, 3);
+
+  const serviceInformation = [];
+  for (const chunk of serviceChunks) {
+    serviceInformation.push(
+      ...(await Promise.all(
+        chunk.map(
+          async (serviceId) =>
+            await getServiceInformation(
+              serviceId,
+              clients,
+              correlationId,
+              selectedRoleIds,
+            ),
+        ),
+      )),
+    );
+  }
+
+  return serviceInformation;
+};
+
+const buildUserDetails = async (
+  userId,
+  organisationId,
+  clients,
+  correlationId,
+) => {
+  if (!userId) {
+    return {
+      sub: "",
+      given_name: "",
+      family_name: "",
+      email: "",
+      status: -1,
+      organisation: await clients.organisations.getOrganisation(
+        organisationId,
+        correlationId,
+      ),
+      roles: [],
+    };
+  }
+
+  const user = await clients.directories.getUserById(userId, correlationId);
+  const userOrganisations = await clients.organisations.getUserOrganisations(
+    userId,
+    correlationId,
+  );
+  const userAccessToSpecifiedOrganisation = userOrganisations.find(
+    (x) => x.organisation.id.toLowerCase() === organisationId.toLowerCase(),
+  );
+  if (userAccessToSpecifiedOrganisation) {
+    user.organisation = userAccessToSpecifiedOrganisation.organisation;
+    user.organisation.role = userAccessToSpecifiedOrganisation.role;
+  }
+
+  return {
+    ...user,
+    id: user.sub,
+  };
+};
+
+const getUserServicesAccess = async (
+  userId,
+  organisationId,
+  serviceIds,
+  clients,
+  correlationId,
+) => {
+  if (!userId) {
+    return new Array(serviceIds.length).fill([]);
+  }
+
+  const serviceAccess = [];
+  const serviceChunks = chunkArray(serviceIds, 10);
+  for (const chunk of serviceChunks) {
+    serviceAccess.push(
+      ...(await Promise.all(
+        chunk.map(
+          async (serviceId) =>
+            (await clients.access.getUserAccessToServiceAtOrganisation(
+              userId,
+              organisationId,
+              serviceId,
+              correlationId,
+            ).roles) || [],
+        ),
+      )),
+    );
+  }
+
+  return serviceAccess;
+};
+
 class PolicyEngine {
   constructor({ directories, organisations, access, applications }) {
     const config = {
@@ -324,29 +372,59 @@ class PolicyEngine {
   async getPolicyApplicationResultsForUser(
     userId,
     organisationId,
-    serviceId,
+    serviceIds,
     correlationId,
   ) {
-    const roles = await this._clients.access.getRolesForService(
-      serviceId,
-      correlationId,
-    );
-    const constraints = await getAndWrapConstraintsForService(
-      serviceId,
-      roles,
-      correlationId,
+    const serviceInfo = await getServicesInformation(
+      serviceIds,
       this._clients,
+      correlationId,
     );
+    const servicesWithPolicies = [];
+    const servicesWithoutPolicies = [];
+    serviceInfo.forEach((service) => {
+      service.policies.length === 0
+        ? servicesWithoutPolicies.push(service)
+        : servicesWithPolicies.push(service);
+    });
 
-    return getAndApplyPoliciesToUser(
-      userId,
-      organisationId,
-      serviceId,
-      correlationId,
-      roles,
-      constraints,
-      this._clients,
-    );
+    const policyResults = servicesWithoutPolicies.map((service) => ({
+      id: service.id,
+      policiesAppliedForUser: [],
+      rolesAvailableToUser: service.roles,
+      serviceAvailableToUser: true,
+    }));
+    if (servicesWithPolicies.length > 0) {
+      const user = await buildUserDetails(
+        userId,
+        organisationId,
+        this._clients,
+        correlationId,
+      );
+      const userAccess = await getUserServicesAccess(
+        userId,
+        organisationId,
+        servicesWithPolicies.map((service) => service.id),
+        this._clients,
+        correlationId,
+      );
+      policyResults.push(
+        ...servicesWithPolicies.map((service, index) => {
+          const userClone = JSON.parse(JSON.stringify(user));
+          userClone.roles = userAccess[index];
+          return {
+            id: service.id,
+            ...applyPoliciesToUser(
+              userClone,
+              service.policies,
+              service.constraints,
+            ),
+          };
+        }),
+      );
+    }
+
+    return policyResults;
   }
 
   async validate(
@@ -356,27 +434,40 @@ class PolicyEngine {
     selectedRoleIds,
     correlationId,
   ) {
-    const roles = await this._clients.access.getRolesForService(
+    const serviceInfo = await getServiceInformation(
       serviceId,
-      correlationId,
-    );
-    const constraints = await getAndWrapConstraintsForService(
-      serviceId,
-      roles,
-      correlationId,
       this._clients,
+      correlationId,
       selectedRoleIds,
     );
 
-    const policyResult = await getAndApplyPoliciesToUser(
-      userId,
-      organisationId,
-      serviceId,
-      correlationId,
-      roles,
-      constraints,
-      this._clients,
-    );
+    let policyResult = {
+      policiesAppliedForUser: [],
+      rolesAvailableToUser: serviceInfo.roles,
+      serviceAvailableToUser: true,
+    };
+    if (serviceInfo.policies.length > 0) {
+      const user = await buildUserDetails(
+        userId,
+        organisationId,
+        this._clients,
+        correlationId,
+      );
+      user.roles = userId
+        ? (await this._clients.access.getUserAccessToServiceAtOrganisation(
+            userId,
+            organisationId,
+            serviceInfo.id,
+            correlationId,
+          ).roles) || []
+        : [];
+      policyResult = applyPoliciesToUser(
+        user,
+        serviceInfo.policies,
+        serviceInfo.constraints,
+      );
+    }
+
     const selectedRolesNotAvailableToUser = selectedRoleIds.filter(
       (rid) =>
         !policyResult.rolesAvailableToUser.find(
@@ -392,7 +483,7 @@ class PolicyEngine {
       ];
     }
 
-    return constraints.validate(selectedRoleIds);
+    return serviceInfo.constraints.validate(selectedRoleIds);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -334,15 +334,16 @@ const getUserServicesAccess = async (
   for (const chunk of serviceChunks) {
     serviceAccess.push(
       ...(await Promise.all(
-        chunk.map(
-          async (serviceId) =>
-            (await clients.access.getUserAccessToServiceAtOrganisation(
+        chunk.map(async (serviceId) => {
+          const userServiceAccess =
+            await clients.access.getUserAccessToServiceAtOrganisation(
               userId,
               organisationId,
               serviceId,
               correlationId,
-            ).roles) || [],
-        ),
+            );
+          return userServiceAccess ? userServiceAccess.roles : [];
+        }),
       )),
     );
   }
@@ -453,14 +454,15 @@ class PolicyEngine {
         this._clients,
         correlationId,
       );
-      user.roles = userId
-        ? (await this._clients.access.getUserAccessToServiceAtOrganisation(
+      const userAccess = userId
+        ? await this._clients.access.getUserAccessToServiceAtOrganisation(
             userId,
             organisationId,
             serviceInfo.id,
             correlationId,
-          ).roles) || []
-        : [];
+          )
+        : undefined;
+      user.roles = userAccess ? userAccess.roles : [];
       policyResult = applyPoliciesToUser(
         user,
         serviceInfo.policies,

--- a/lib/infrastructure/access/index.js
+++ b/lib/infrastructure/access/index.js
@@ -20,9 +20,5 @@ class AccessClient extends ApiClient {
   async getRolesForService(serviceId, correlationId) {
     return this._callApi(`/services/${serviceId}/roles`, correlationId);
   }
-
-  async getConstraintsForService(serviceId, correlationId) {
-    return this._callApi(`/services/${serviceId}/constraints`, correlationId);
-  }
 }
 module.exports = AccessClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.0",
+  "version": "4.0.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.policy-engine",
-      "version": "4.0.0",
+      "version": "4.0.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "3.1.4",
+  "version": "4.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.policy-engine",
-      "version": "3.1.4",
+      "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,9 +548,9 @@
       "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-      "integrity": "sha1-5MWP3PBpbnpfGcMCAe1DEjqxWrw=",
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha1-cwjfFY4GTw3YuP21iqFPoqf5E7M=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,13 +590,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha1-ehIy6CN2cS0zQAEqL1YaJ2TRmI8=",
+      "version": "0.21.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha1-fRsAYP6kB/gwHpMkkrqMGK/ylxM=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -605,19 +605,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-helpers/-/config-helpers-0.2.1.tgz",
-      "integrity": "sha1-JgQsAo0b7uXOIjWnkpuRxSZRZG0=",
+      "version": "0.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha1-G9AGzut+LlWyt3OrMY0wDhpmrto=",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha1-vwLyCYRtO/mW+egAnbYt8nObRYw=",
+      "version": "0.17.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha1-dyJYIEE9lhdQnak0IZCiAZ54dhw=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -665,19 +668,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.25.1.tgz",
-      "integrity": "sha1-JfXJMMK2i16+eshX91TL1h720Rc=",
+      "version": "9.39.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha1-LUuOxMPqE8GzdI4Ml+zXZr3YBZk=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha1-WDaatbWzyhF4gMD2wLDzL2lQ8k8=",
+      "version": "2.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha1-biEmoTR+hqTe34cG7Gf/jhB+u60=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -685,13 +691,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha1-R0iNj4FxtdRhPoMzE/POcI41Jfg=",
+      "version": "0.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha1-l3nj/Zt+4zVxpXQ1z0M1oXlKbLI=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -803,10 +809,11 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1438,9 +1445,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1519,9 +1526,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha1-ch1dwQ99W1YJqJF3PUdzF5aTXfs=",
+      "version": "8.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha1-o2CJi8QV7arEbIJB9jg5dbkwuBY=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1743,10 +1750,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2245,33 +2253,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.25.1.tgz",
-      "integrity": "sha1-inz43Q5qy4WPhgKXIK2xeF7ldYA=",
+      "version": "9.39.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha1-y2Dm0WqyNMD4Npo/58yHln+vS2w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.25.1",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2342,9 +2349,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha1-EM06kY/91yL18/e1uD25sjyHNA0=",
+      "version": "8.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha1-iOZGogf61hQ2/6OetQUUcgBlXII=",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2359,9 +2366,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha1-aHussq+IT83aim59ZcYG9GoUzUU=",
+      "version": "4.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha1-TP6mD+fdCtjoFuHtAmwdUlG1EsE=",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2372,15 +2379,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha1-KSZ89bDLmHNbZeZLoH4O1J0e7Yo=",
+      "version": "10.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha1-1U9JSdRikAWh+haNk3w/8ffiqDc=",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3688,9 +3695,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+      "version": "4.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3786,23 +3793,23 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "version": "1.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha1-FgEaxttI3nsQJ3fleJeQFSDux7k=",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "version": "3.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha1-WsBpC0YJAKJyZd4kUgUmhTwLjKE=",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.policy-engine",
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.1-alpha.1",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.policy-engine",
-      "version": "4.0.1-alpha.1",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "3.1.4",
+  "version": "4.0.0-alpha.1",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.0",
+  "version": "4.0.1-alpha.1",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "4.0.1-alpha.1",
+  "version": "4.0.1",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -151,14 +151,17 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: allServiceRoles,
-      serviceAvailableToUser: true,
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: allServiceRoles,
+        serviceAvailableToUser: true,
+      },
+    ]);
   });
 
   it("then it should return no roles if user matches no policy", async () => {
@@ -181,13 +184,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+      },
+    ]);
   });
 
   it("then it should return policy roles when user matches organisation criteria", async () => {
@@ -210,13 +216,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
+      },
+    ]);
   });
 
   it("then it should return policy roles when user matches user criteria", async () => {
@@ -239,13 +248,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
+      },
+    ]);
   });
 
   it("then it should return policy roles when user matches roles criteria", async () => {
@@ -268,13 +280,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
+      },
+    ]);
   });
 
   it("then it should not try and get user from directories if userId is undefined", async () => {
@@ -297,7 +312,7 @@ describe("When getting available roles for a user", () => {
     await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
@@ -324,13 +339,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
+      },
+    ]);
   });
 
   it("then it should not return policy roles criteria is based on user and userId is undefined", async () => {
@@ -353,13 +371,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+      },
+    ]);
   });
 
   it("then it should treat no values as a false when applying conditions", async () => {
@@ -390,13 +411,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[0]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0]],
+      },
+    ]);
   });
 
   it("then it should remove roles that violate a single constraint", async () => {
@@ -422,13 +446,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [allServiceRoles[1], allServiceRoles[2]],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[1], allServiceRoles[2]],
+      },
+    ]);
   });
 
   it("then it should remove roles that violate multiple constraints", async () => {
@@ -457,13 +484,16 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [],
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+      },
+    ]);
   });
 
   it("then it should make service unavailable to user if constraints and no roles", async () => {
@@ -489,14 +519,17 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [],
-      serviceAvailableToUser: false,
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: false,
+      },
+    ]);
   });
 
   it("then it should make service available to user if no roles but no constraints", async () => {
@@ -528,13 +561,79 @@ describe("When getting available roles for a user", () => {
     const actual = await engine.getPolicyApplicationResultsForUser(
       undefined,
       organisationId,
-      serviceId,
+      [serviceId],
       correlationId,
     );
 
-    expect(actual).toMatchObject({
-      rolesAvailableToUser: [],
-      serviceAvailableToUser: true,
-    });
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: true,
+      },
+    ]);
+  });
+
+  it("then it should call getUserAccessToServiceAtOrganisation for each service if the user ID is passed in and the services have policies", async () => {
+    accessClient.getPoliciesForService.mockReturnValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.id",
+            operator: "is",
+            value: [organisationId],
+          },
+        ],
+        roles: [],
+      },
+    ]);
+    await engine.getPolicyApplicationResultsForUser(
+      userId,
+      organisationId,
+      [serviceId, "service-2"],
+      correlationId,
+    );
+
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).toHaveBeenCalledWith(userId, organisationId, serviceId, correlationId);
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).toHaveBeenCalledWith(userId, organisationId, "service-2", correlationId);
+  });
+
+  it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the services have policies", async () => {
+    accessClient.getPoliciesForService.mockReturnValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.id",
+            operator: "is",
+            value: [organisationId],
+          },
+        ],
+        roles: [],
+      },
+    ]);
+
+    await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId, "service-2"],
+      correlationId,
+    );
+
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -63,7 +63,7 @@ const userAccessToService = {
   userId: "user-1",
   organisationId: "organisation-1",
   serviceId: "service-1",
-  roles: ["role-1"],
+  roles: [{ id: "role-1", name: "role 1", code: "r1" }],
 };
 const userId = "user-1";
 const organisationId = "organisation-1";
@@ -74,27 +74,27 @@ describe("When getting available roles for a user", () => {
   let engine;
 
   beforeEach(() => {
-    directoriesClient.getUserById.mockReset().mockReturnValue(user);
+    directoriesClient.getUserById.mockReset().mockResolvedValue(user);
     DirectoriesClient.mockImplementation(() => directoriesClient);
 
     organisationsClient.getUserOrganisations
       .mockReset()
-      .mockReturnValue(userOrganisations);
+      .mockResolvedValue(userOrganisations);
     organisationsClient.getOrganisation
       .mockReset()
-      .mockReturnValue(userOrganisations[0].organisation);
+      .mockResolvedValue(userOrganisations[0].organisation);
     OrganisationsClient.mockImplementation(() => organisationsClient);
 
     accessClient.getPoliciesForService.mockReset();
     accessClient.getUserAccessToServiceAtOrganisation
       .mockReset()
-      .mockReturnValue(userAccessToService);
+      .mockResolvedValue(userAccessToService);
     accessClient.getRolesForService
       .mockReset()
-      .mockReturnValue(allServiceRoles);
+      .mockResolvedValue(allServiceRoles);
     AccessClient.mockImplementation(() => accessClient);
 
-    applicationsClient.getService.mockReset().mockReturnValue({
+    applicationsClient.getService.mockReset().mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -146,7 +146,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return all roles for service if no policies", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([]);
+    accessClient.getPoliciesForService.mockResolvedValue([]);
 
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
@@ -165,7 +165,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return no roles if user matches no policy", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -197,7 +197,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return policy roles when user matches organisation criteria", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -229,7 +229,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return policy roles when user matches user criteria", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -261,21 +261,20 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return policy roles when user matches roles criteria", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
-      {
-        id: "policy-1",
-        name: "policy one",
-        applicationId: serviceId,
-        conditions: [
-          {
-            field: "roles",
-            operator: "is",
-            value: [userAccessToService.roles[0]],
-          },
-        ],
-        roles: [allServiceRoles[0], allServiceRoles[2]],
-      },
-    ]);
+    const policy = {
+      id: "policy-1",
+      name: "policy one",
+      applicationId: serviceId,
+      conditions: [
+        {
+          field: "roles.id",
+          operator: "is",
+          value: [userAccessToService.roles[0].id],
+        },
+      ],
+      roles: [allServiceRoles[0], allServiceRoles[2]],
+    };
+    accessClient.getPoliciesForService.mockResolvedValue([policy]);
 
     const actual = await engine.getPolicyApplicationResultsForUser(
       userId,
@@ -287,13 +286,14 @@ describe("When getting available roles for a user", () => {
     expect(actual).toMatchObject([
       {
         id: serviceId,
+        policiesAppliedForUser: [policy],
         rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[2]],
       },
     ]);
   });
 
   it("then it should not try and get user from directories if userId is undefined", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -320,7 +320,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should return policy roles when user matches organisation criteria and userId is undefined", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -352,7 +352,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should not return policy roles criteria is based on user and userId is undefined", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -384,14 +384,14 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should treat no values as a false when applying conditions", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
         applicationId: serviceId,
         conditions: [
           {
-            field: "role.id",
+            field: "roles.id",
             operator: "is_not",
             value: "something",
           },
@@ -401,7 +401,7 @@ describe("When getting available roles for a user", () => {
     ]);
     accessClient.getUserAccessToServiceAtOrganisation
       .mockReset()
-      .mockReturnValue({
+      .mockResolvedValue({
         userId: "user-1",
         organisationId: "organisation-1",
         serviceId: "service-1",
@@ -427,7 +427,7 @@ describe("When getting available roles for a user", () => {
     parentChildConstraint.apply.mockImplementation((availableRoles) => {
       return availableRoles.filter((x) => x === "role-1");
     });
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -465,7 +465,7 @@ describe("When getting available roles for a user", () => {
     parentChildConstraint.apply.mockImplementation((availableRoles) => {
       return availableRoles.filter((x) => x === "role-1");
     });
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -500,7 +500,7 @@ describe("When getting available roles for a user", () => {
     parentChildConstraint.apply.mockImplementation(
       (availableRoles) => availableRoles,
     );
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -536,7 +536,7 @@ describe("When getting available roles for a user", () => {
     parentChildConstraint.apply.mockImplementation(
       (availableRoles) => availableRoles,
     );
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -551,7 +551,7 @@ describe("When getting available roles for a user", () => {
         roles: [],
       },
     ]);
-    applicationsClient.getService.mockReset().mockReturnValue({
+    applicationsClient.getService.mockReset().mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {},
@@ -575,7 +575,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should call getUserAccessToServiceAtOrganisation for each service if the user ID is passed in and the services have policies", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -609,7 +609,7 @@ describe("When getting available roles for a user", () => {
   });
 
   it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the services have policies", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",

--- a/test/PolicyEngine.validate.test.js
+++ b/test/PolicyEngine.validate.test.js
@@ -85,18 +85,18 @@ describe("when validating selected roles", () => {
   let engine;
 
   beforeEach(() => {
-    directoriesClient.getUserById.mockReset().mockReturnValue(user);
+    directoriesClient.getUserById.mockReset().mockResolvedValue(user);
     DirectoriesClient.mockImplementation(() => directoriesClient);
 
     organisationsClient.getUserOrganisations
       .mockReset()
-      .mockReturnValue(userOrganisations);
+      .mockResolvedValue(userOrganisations);
     organisationsClient.getOrganisation
       .mockReset()
-      .mockReturnValue(userOrganisations[0].organisation);
+      .mockResolvedValue(userOrganisations[0].organisation);
     OrganisationsClient.mockImplementation(() => organisationsClient);
 
-    accessClient.getPoliciesForService.mockReset().mockReturnValue([
+    accessClient.getPoliciesForService.mockReset().mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -113,13 +113,13 @@ describe("when validating selected roles", () => {
     ]);
     accessClient.getUserAccessToServiceAtOrganisation
       .mockReset()
-      .mockReturnValue(userAccessToService);
+      .mockResolvedValue(userAccessToService);
     accessClient.getRolesForService
       .mockReset()
-      .mockReturnValue(allServiceRoles);
+      .mockResolvedValue(allServiceRoles);
     AccessClient.mockImplementation(() => accessClient);
 
-    applicationsClient.getService.mockReset().mockReturnValue({
+    applicationsClient.getService.mockReset().mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -233,7 +233,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should not apply minimum constraint if not configured for service", async () => {
-    applicationsClient.getService.mockReturnValue({
+    applicationsClient.getService.mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -294,7 +294,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should not apply maximum constraint if not configured for service", async () => {
-    applicationsClient.getService.mockReturnValue({
+    applicationsClient.getService.mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -357,7 +357,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should not apply parent/child constraint if not configured for service", async () => {
-    applicationsClient.getService.mockReturnValue({
+    applicationsClient.getService.mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -442,7 +442,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should apply Selection constraint if configured for service", async () => {
-    applicationsClient.getService.mockReturnValue({
+    applicationsClient.getService.mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -469,7 +469,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should not apply Selection constraint if not configured for service", async () => {
-    applicationsClient.getService.mockReturnValue({
+    applicationsClient.getService.mockResolvedValue({
       id: serviceId,
       relyingParty: {
         params: {
@@ -492,7 +492,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should call getUserAccessToServiceAtOrganisation if the user ID is passed in and the service has policies", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",
@@ -524,7 +524,7 @@ describe("when validating selected roles", () => {
   });
 
   it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the service has policies", async () => {
-    accessClient.getPoliciesForService.mockReturnValue([
+    accessClient.getPoliciesForService.mockResolvedValue([
       {
         id: "policy-1",
         name: "policy one",

--- a/test/PolicyEngine.validate.test.js
+++ b/test/PolicyEngine.validate.test.js
@@ -490,4 +490,65 @@ describe("when validating selected roles", () => {
     expect(SelectionConstraint).toHaveBeenCalledTimes(0);
     expect(selectionConstraint.validate).toHaveBeenCalledTimes(0);
   });
+
+  it("then it should call getUserAccessToServiceAtOrganisation if the user ID is passed in and the service has policies", async () => {
+    accessClient.getPoliciesForService.mockReturnValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.id",
+            operator: "is",
+            value: [organisationId],
+          },
+        ],
+        roles: [],
+      },
+    ]);
+    await engine.validate(
+      userId,
+      organisationId,
+      serviceId,
+      selectedRoleIds,
+      correlationId,
+    );
+
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).toHaveBeenCalledWith(userId, organisationId, serviceId, correlationId);
+  });
+
+  it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the service has policies", async () => {
+    accessClient.getPoliciesForService.mockReturnValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.id",
+            operator: "is",
+            value: [organisationId],
+          },
+        ],
+        roles: [],
+      },
+    ]);
+    await engine.validate(
+      undefined,
+      organisationId,
+      serviceId,
+      selectedRoleIds,
+      correlationId,
+    );
+
+    expect(
+      accessClient.getUserAccessToServiceAtOrganisation,
+    ).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
_This change is documented in far greater detail in the associated work item as well as the linked Confluence page in the work item._

The policy engine was originally not built for scale, handling things one at a time for getting the policy results leads to duplicated work and a lack of concurrency, both of which lead to longer load times for pages needing that information when calling the `getPolicyApplicationResultsForUser` function.

This PR aims to fix that by implementing the following changes:
- `getPolicyApplicationResultsForUser` now takes in an array of service IDs and does the following:
  - Retrieves the service information concurrently: 9 requests total at a time as 3 requests are needed for the information and the services are chunked into groups of 3.
  - If any services contain policies then the user details are retrieved only once, as opposed to the previous implementation where it was retrieved once per service.
  - Retrieves the user's access to the services at the organisation concurrently in groups of 10 to try and avoid hammering our APIs by doing all services at once. Whilst I'm confident in our infrastructure this is already a vast improvement and I don't want to push things too far.
  - Returns an array of results for each service containing their ID, and then the policies applied, roles available, and whether the service is available to the user.

I also removed an unused API call where the endpoint no longer exists, and it wasn't being used in our code. **I went out of my way not to touch the actual policy condition checking** to ensure that didn't fail, and have merely improved how we grab the data for the services and access to improve loading times.

I also kept the way we clone the user object to avoid any side-effects as `JSON.parse(JSON.stringify(user))` and the reason for this is `Jest` didn't play nicely with the `structuredClone` function as it doesn't copy the prototype in the `Jest` runner, so `instanceof` returned the wrong result and I didn't want to change anything related to the policy comparison section to avoid breaking that.