### PR TITLE
[NSA-9733] Add SQL migration for UKRLP category 054 policy

### DIFF
--- a/database_scripts/008_add_ukrlp_category_054_policy.sql
+++ b/database_scripts/008_add_ukrlp_category_054_policy.sql
@@ -1,0 +1,45 @@
+-- NSA-9733: UKRLP Provider Profile Integration
+-- Creates a policy granting UKRLP organisations (category 054) access to the UKRLP service.
+-- Run once per environment using the environment-specific service ID below.
+--
+-- Dev  service ID: 0DB75A65-C27F-4700-B5F1-0448089C3E01
+-- Test service ID: CFBEEBEA-05ED-413E-8240-BB5497866AA0
+
+BEGIN TRANSACTION AddUKRLPPolicy
+
+  DECLARE @policyId    UNIQUEIDENTIFIER = NEWID()
+  DECLARE @ukRlpServiceId UNIQUEIDENTIFIER
+
+  -- Set the correct service ID for the target environment before running:
+  -- Dev:  SET @ukRlpServiceId = '0DB75A65-C27F-4700-B5F1-0448089C3E01'
+  -- Test: SET @ukRlpServiceId = 'CFBEEBEA-05ED-413E-8240-BB5497866AA0'
+  SET @ukRlpServiceId = '<ENV_SERVICE_ID>'
+
+  INSERT INTO Policy (Id, Name, ApplicationId, Status, CreatedAt, UpdatedAt)
+  VALUES (
+    @policyId,
+    'UKRLP - Category 054 Access',
+    @ukRlpServiceId,
+    1,
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @policyId,
+    'organisation.category.id',
+    'is',
+    '054',
+    GETDATE(),
+    GETDATE()
+  )
+
+  -- Grant all roles defined for the UKRLP service
+  INSERT INTO PolicyRole (PolicyId, RoleId, CreatedAt, UpdatedAt)
+  SELECT @policyId, r.Id, GETDATE(), GETDATE()
+  FROM Role r
+  WHERE r.applicationId = @ukRlpServiceId
+
+COMMIT TRANSACTION AddUKRLPPolicy

--- a/database_scripts/009_add_ukrlp_ukprn_policy.sql
+++ b/database_scripts/009_add_ukrlp_ukprn_policy.sql
@@ -1,0 +1,54 @@
+-- NSA-9764: UKRLP UKPRN-based access policy
+-- Creates a second policy granting access to the UKRLP service for any organisation
+-- whose UKPRN begins with '1'. This works alongside the category-054 policy from
+-- migration 008 (NSA-9733) — together they implement the OR logic:
+--   "org category = UKRLP (054)" OR "org has a UKPRN starting with 1"
+--
+-- The policy engine evaluates multiple policies as OR: if ANY policy's conditions
+-- are met, the user is granted access. Two policies are required here because
+-- conditions within a single policy are AND'd.
+--
+-- Service IDs (environment-specific):
+--   Dev:  0DB75A65-C27F-4700-B5F1-0448089C3E01
+--   Test: CFBEEBEA-05ED-413E-8240-BB5497866AA0
+
+BEGIN TRANSACTION AddUKRLPUkprnPolicy
+
+  DECLARE @policyId       UNIQUEIDENTIFIER = NEWID()
+  DECLARE @ukRlpServiceId UNIQUEIDENTIFIER
+
+  -- Set the correct service ID for the target environment before running:
+  -- Dev:  SET @ukRlpServiceId = '0DB75A65-C27F-4700-B5F1-0448089C3E01'
+  -- Test: SET @ukRlpServiceId = 'CFBEEBEA-05ED-413E-8240-BB5497866AA0'
+  SET @ukRlpServiceId = '<ENV_SERVICE_ID>'
+
+  INSERT INTO Policy (Id, Name, ApplicationId, Status, CreatedAt, UpdatedAt)
+  VALUES (
+    @policyId,
+    'UKRLP - UKPRN starts with 1',
+    @ukRlpServiceId,
+    1,
+    GETDATE(),
+    GETDATE()
+  )
+
+  -- Condition: organisation.ukprn starts_with '1'
+  -- Requires the starts_with operator added to the policy engine in NSA-9764
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @policyId,
+    'organisation.ukprn',
+    'starts_with',
+    '1',
+    GETDATE(),
+    GETDATE()
+  )
+
+  -- Grant all roles defined for the UKRLP service
+  INSERT INTO PolicyRole (PolicyId, RoleId, CreatedAt, UpdatedAt)
+  SELECT @policyId, r.Id, GETDATE(), GETDATE()
+  FROM Role r
+  WHERE r.applicationId = @ukRlpServiceId
+
+COMMIT TRANSACTION AddUKRLPUkprnPolicy

--- a/database_scripts/010_combine_ukrlp_category_and_ukprn_policy.sql
+++ b/database_scripts/010_combine_ukrlp_category_and_ukprn_policy.sql
@@ -1,0 +1,75 @@
+-- NSA-9764: Combine UKRLP category and UKPRN conditions into a single AND'd policy
+--
+-- Clarification from the UKRLP team: the UKPRN-starts-with-"1" condition is only
+-- meant to apply to organisations sourced purely from UKRLP (i.e. not also a member
+-- of GIAS and/or PIMS) — which is exactly the set of organisations with category
+-- '054'. The two conditions must be AND'd, not OR'd, otherwise the UKPRN condition
+-- alone would incorrectly grant UKRLP access to any GIAS/PIMS organisation whose
+-- UKPRN happens to start with "1" (the vast majority of UKPRNs do).
+--
+-- This migration:
+--   1. Deactivates the two separate OR'd policies added in 008 and 009
+--   2. Creates one combined policy: organisation.category.id is '054'
+--      AND organisation.ukprn starts_with '1'
+--
+-- Run once per environment using the environment-specific service ID below.
+--
+-- Dev  service ID: 0DB75A65-C27F-4700-B5F1-0448089C3E01
+-- Test service ID: CFBEEBEA-05ED-413E-8240-BB5497866AA0
+
+BEGIN TRANSACTION CombineUKRLPPolicies
+
+  DECLARE @policyId       UNIQUEIDENTIFIER = NEWID()
+  DECLARE @ukRlpServiceId UNIQUEIDENTIFIER
+
+  -- Set the correct service ID for the target environment before running:
+  -- Dev:  SET @ukRlpServiceId = '0DB75A65-C27F-4700-B5F1-0448089C3E01'
+  -- Test: SET @ukRlpServiceId = 'CFBEEBEA-05ED-413E-8240-BB5497866AA0'
+  SET @ukRlpServiceId = '<ENV_SERVICE_ID>'
+
+  -- 1. Deactivate the previous separate (OR'd) policies
+  UPDATE Policy
+  SET Status = 0, UpdatedAt = GETDATE()
+  WHERE ApplicationId = @ukRlpServiceId
+    AND Name IN ('UKRLP - Category 054 Access', 'UKRLP - UKPRN starts with 1')
+
+  -- 2. Create the combined policy with both conditions AND'd
+  INSERT INTO Policy (Id, Name, ApplicationId, Status, CreatedAt, UpdatedAt)
+  VALUES (
+    @policyId,
+    'UKRLP - Category 054 and UKPRN starts with 1',
+    @ukRlpServiceId,
+    1,
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @policyId,
+    'organisation.category.id',
+    'is',
+    '054',
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @policyId,
+    'organisation.ukprn',
+    'starts_with',
+    '1',
+    GETDATE(),
+    GETDATE()
+  )
+
+  -- Grant all roles defined for the UKRLP service
+  INSERT INTO PolicyRole (PolicyId, RoleId, CreatedAt, UpdatedAt)
+  SELECT @policyId, r.Id, GETDATE(), GETDATE()
+  FROM Role r
+  WHERE r.applicationId = @ukRlpServiceId
+
+COMMIT TRANSACTION CombineUKRLPPolicies

--- a/database_scripts/011_revert_to_separate_ukrlp_policies.sql
+++ b/database_scripts/011_revert_to_separate_ukrlp_policies.sql
@@ -1,0 +1,38 @@
+-- NSA-9764: Revert to separate OR'd UKRLP policies
+--
+-- The UKRLP team has reconsidered and confirmed they want the original OR
+-- behaviour after all: an organisation should gain UKRLP service access if
+-- EITHER its category is '054' OR its UKPRN starts with "1" (evaluated as
+-- two separate policies, not one combined AND'd policy).
+--
+-- This migration reverses migration 010:
+--   1. Reactivates the two original separate policies from 008 and 009
+--   2. Deactivates the combined AND'd policy added in 010
+--
+-- Run once per environment using the environment-specific service ID below.
+--
+-- Dev  service ID: 0DB75A65-C27F-4700-B5F1-0448089C3E01
+-- Test service ID: CFBEEBEA-05ED-413E-8240-BB5497866AA0
+
+BEGIN TRANSACTION RevertToSeparateUKRLPPolicies
+
+  DECLARE @ukRlpServiceId UNIQUEIDENTIFIER
+
+  -- Set the correct service ID for the target environment before running:
+  -- Dev:  SET @ukRlpServiceId = '0DB75A65-C27F-4700-B5F1-0448089C3E01'
+  -- Test: SET @ukRlpServiceId = 'CFBEEBEA-05ED-413E-8240-BB5497866AA0'
+  SET @ukRlpServiceId = '<ENV_SERVICE_ID>'
+
+  -- 1. Reactivate the original separate (OR'd) policies
+  UPDATE Policy
+  SET Status = 1, UpdatedAt = GETDATE()
+  WHERE ApplicationId = @ukRlpServiceId
+    AND Name IN ('UKRLP - Category 054 Access', 'UKRLP - UKPRN starts with 1')
+
+  -- 2. Deactivate the combined AND'd policy from migration 010
+  UPDATE Policy
+  SET Status = 0, UpdatedAt = GETDATE()
+  WHERE ApplicationId = @ukRlpServiceId
+    AND Name = 'UKRLP - Category 054 and UKPRN starts with 1'
+
+COMMIT TRANSACTION RevertToSeparateUKRLPPolicies

--- a/database_scripts/012_recreate_separate_ukrlp_policies.sql
+++ b/database_scripts/012_recreate_separate_ukrlp_policies.sql
@@ -1,0 +1,88 @@
+-- NSA-9764: Recreate the separate OR'd UKRLP policies
+--
+-- Migration 011 attempted to reactivate the original policies from 008/009
+-- by setting Status = 1, but they no longer exist in this environment (they
+-- were removed entirely, not just deactivated, likely via manual cleanup
+-- through the manage console after migration 010 ran). This migration
+-- recreates them fresh as new policies.
+--
+-- This also deactivates the combined AND'd policy from 010, since the
+-- UKRLP team confirmed they want OR behaviour, not AND.
+--
+-- Run once per environment using the environment-specific service ID below.
+--
+-- Dev  service ID: 0DB75A65-C27F-4700-B5F1-0448089C3E01
+-- Test service ID: CFBEEBEA-05ED-413E-8240-BB5497866AA0
+
+BEGIN TRANSACTION RecreateSeparateUKRLPPolicies
+
+  DECLARE @categoryPolicyId UNIQUEIDENTIFIER = NEWID()
+  DECLARE @ukprnPolicyId    UNIQUEIDENTIFIER = NEWID()
+  DECLARE @ukRlpServiceId   UNIQUEIDENTIFIER
+
+  -- Set the correct service ID for the target environment before running:
+  -- Dev:  SET @ukRlpServiceId = '0DB75A65-C27F-4700-B5F1-0448089C3E01'
+  -- Test: SET @ukRlpServiceId = 'CFBEEBEA-05ED-413E-8240-BB5497866AA0'
+  SET @ukRlpServiceId = '<ENV_SERVICE_ID>'
+
+  -- 1. Deactivate the combined AND'd policy from migration 010 (if present)
+  UPDATE Policy
+  SET Status = 0, UpdatedAt = GETDATE()
+  WHERE ApplicationId = @ukRlpServiceId
+    AND Name = 'UKRLP - Category 054 and UKPRN starts with 1'
+
+  -- 2. Recreate "UKRLP - Category 054 Access"
+  INSERT INTO Policy (Id, Name, ApplicationId, Status, CreatedAt, UpdatedAt)
+  VALUES (
+    @categoryPolicyId,
+    'UKRLP - Category 054 Access',
+    @ukRlpServiceId,
+    1,
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @categoryPolicyId,
+    'organisation.category.id',
+    'is',
+    '054',
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyRole (PolicyId, RoleId, CreatedAt, UpdatedAt)
+  SELECT @categoryPolicyId, r.Id, GETDATE(), GETDATE()
+  FROM Role r
+  WHERE r.applicationId = @ukRlpServiceId
+
+  -- 3. Recreate "UKRLP - UKPRN starts with 1"
+  INSERT INTO Policy (Id, Name, ApplicationId, Status, CreatedAt, UpdatedAt)
+  VALUES (
+    @ukprnPolicyId,
+    'UKRLP - UKPRN starts with 1',
+    @ukRlpServiceId,
+    1,
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyCondition (Id, PolicyId, Field, Operator, Value, CreatedAt, UpdatedAt)
+  VALUES (
+    NEWID(),
+    @ukprnPolicyId,
+    'organisation.ukprn',
+    'starts_with',
+    '1',
+    GETDATE(),
+    GETDATE()
+  )
+
+  INSERT INTO PolicyRole (PolicyId, RoleId, CreatedAt, UpdatedAt)
+  SELECT @ukprnPolicyId, r.Id, GETDATE(), GETDATE()
+  FROM Role r
+  WHERE r.applicationId = @ukRlpServiceId
+
+COMMIT TRANSACTION RecreateSeparateUKRLPPolicies

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,18 @@ const extractFieldsFromUser = (model, parentPath) => {
 
 const isConditionFulfilled = (condition, userFields) => {
   const actual = userFields.filter((x) => x.path === condition.field);
+
+  if (condition.operator === "starts_with") {
+    return (
+      actual.length > 0 &&
+      condition.value.some((prefix) =>
+        actual.some((y) =>
+          y.value.toLowerCase().startsWith(prefix.toLowerCase()),
+        ),
+      )
+    );
+  }
+
   const matchValue = condition.operator === "is";
   const match =
     actual &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,9 +150,10 @@ const getAndWrapConstraintsForService = async (
   selectedRoleIds,
 ) => {
   const service = await getServiceRaw({ by: { serviceId } });
-  const serviceParams = service.relyingParty.params
-    ? service.relyingParty.params
-    : {};
+  if (!service) {
+    return { constraints: [], length: 0, apply: () => [], validate: () => [] };
+  }
+  const serviceParams = service.relyingParty?.params ?? {};
   const constraints = [];
 
   let roleSelectionConstraint = serviceParams["roleSelectionConstraint"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -208,7 +208,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.4.tgz",
       "integrity": "sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -1391,7 +1390,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha1-0D66aCc9wPdQnio9XLoh6uEDef4=",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1898,7 +1896,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha1-o2CJi8QV7arEbIJB9jg5dbkwuBY=",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2248,7 +2245,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -2847,7 +2843,6 @@
       "integrity": "sha1-y2Dm0WqyNMD4Npo/58yHln+vS2w=",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3723,7 +3718,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "5.0.1",
+  "version": "5.0.3",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -655,4 +655,114 @@ describe("When getting available roles for a user", () => {
 
     expect(getUserServiceRaw).not.toHaveBeenCalled();
   });
+
+  it("then it should return policy roles when organisation ukprn matches starts_with condition", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+      ukprn: "10070901",
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[1]],
+        serviceAvailableToUser: true,
+      },
+    ]);
+  });
+
+  it("then it should not return policy roles when organisation ukprn does not match starts_with condition", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+      ukprn: "20070901",
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: false,
+      },
+    ]);
+  });
+
+  it("then it should not return policy roles when organisation ukprn is absent and starts_with condition is set", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: false,
+      },
+    ]);
+  });
 });

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -635,4 +635,114 @@ describe("When getting available roles for a user", () => {
 
     expect(getUserServiceRaw).not.toHaveBeenCalled();
   });
+
+  it("then it should return policy roles when organisation ukprn matches starts_with condition", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+      ukprn: "10070901",
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [allServiceRoles[0], allServiceRoles[1]],
+        serviceAvailableToUser: true,
+      },
+    ]);
+  });
+
+  it("then it should not return policy roles when organisation ukprn does not match starts_with condition", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+      ukprn: "20070901",
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: false,
+      },
+    ]);
+  });
+
+  it("then it should not return policy roles when organisation ukprn is absent and starts_with condition is set", async () => {
+    getOrganisationRaw.mockResolvedValue({
+      id: organisationId,
+    });
+    getServicePoliciesRaw.mockResolvedValue([
+      {
+        id: "policy-1",
+        name: "policy one",
+        applicationId: serviceId,
+        conditions: [
+          {
+            field: "organisation.ukprn",
+            operator: "starts_with",
+            value: ["1"],
+          },
+        ],
+        roles: [allServiceRoles[0], allServiceRoles[1]],
+      },
+    ]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      undefined,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: false,
+      },
+    ]);
+  });
 });

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -609,6 +609,26 @@ describe("When getting available roles for a user", () => {
     });
   });
 
+  it("then it should not throw and treat the service as unconstrained when getServiceRaw returns undefined", async () => {
+    getServiceRaw.mockReset().mockResolvedValue(undefined);
+    getServicePoliciesRaw.mockResolvedValue([]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      userId,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: allServiceRoles,
+        serviceAvailableToUser: true,
+      },
+    ]);
+  });
+
   it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the services have policies", async () => {
     getServicePoliciesRaw.mockResolvedValue([
       {

--- a/test/PolicyEngine.validate.test.js
+++ b/test/PolicyEngine.validate.test.js
@@ -550,4 +550,19 @@ describe("when validating selected roles", () => {
 
     expect(getUserServiceRaw).not.toHaveBeenCalled();
   });
+
+  it("then it should not throw and return no validation errors when getServiceRaw returns undefined", async () => {
+    getServiceRaw.mockReset().mockResolvedValue(undefined);
+    getServicePoliciesRaw.mockResolvedValue([]);
+
+    const actual = await engine.validate(
+      userId,
+      organisationId,
+      serviceId,
+      [],
+      correlationId,
+    );
+
+    expect(actual).toEqual([]);
+  });
 });


### PR DESCRIPTION
database_scripts/008_add_ukrlp_category_054_policy.sql (new file)

- Creates a policy granting UKRLP organisations (category 054) access to the UKRLP service
- Policy condition: organisation.category.id is 054
- Grants all roles defined for the UKRLP service
- Must be run per environment with the correct service ID substituted for <ENV_SERVICE_ID>:
  - Dev: 0DB75A65-C27F-4700-B5F1-0448089C3E01
  - Test: CFBEEBEA-05ED-413E-8240-BB5497866AA0