### PR TITLE
NSA-9817: Guard against undefined service in getAndWrapConstraintsFor service

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -150,9 +150,10 @@ const getAndWrapConstraintsForService = async (
   selectedRoleIds,
 ) => {
   const service = await getServiceRaw({ by: { serviceId } });
-  const serviceParams = service.relyingParty.params
-    ? service.relyingParty.params
-    : {};
+  if (!service) {
+    return { constraints: [], length: 0, apply: () => [], validate: () => [] };
+  }
+  const serviceParams = service.relyingParty?.params ?? {};
   const constraints = [];
 
   let roleSelectionConstraint = serviceParams["roleSelectionConstraint"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.policy-engine",
-  "version": "5.0.1",
+  "version": "5.0.3",
   "description": "Applies access policies to determine available roles for users",
   "main": "lib/index.js",
   "scripts": {

--- a/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
+++ b/test/PolicyEngine.getPolicyApplicationResultsForUser.test.js
@@ -609,6 +609,26 @@ describe("When getting available roles for a user", () => {
     });
   });
 
+  it("then it should not throw and treat the service as unconstrained when getServiceRaw returns undefined", async () => {
+    getServiceRaw.mockReset().mockResolvedValue(undefined);
+    getServicePoliciesRaw.mockResolvedValue([]);
+
+    const actual = await engine.getPolicyApplicationResultsForUser(
+      userId,
+      organisationId,
+      [serviceId],
+      correlationId,
+    );
+
+    expect(actual).toMatchObject([
+      {
+        id: serviceId,
+        rolesAvailableToUser: allServiceRoles,
+        serviceAvailableToUser: true,
+      },
+    ]);
+  });
+
   it("then it should not call getUserAccessToServiceAtOrganisation if the user ID is not passed in and the services have policies", async () => {
     getServicePoliciesRaw.mockResolvedValue([
       {

--- a/test/PolicyEngine.validate.test.js
+++ b/test/PolicyEngine.validate.test.js
@@ -550,4 +550,19 @@ describe("when validating selected roles", () => {
 
     expect(getUserServiceRaw).not.toHaveBeenCalled();
   });
+
+  it("then it should not throw and return no validation errors when getServiceRaw returns undefined", async () => {
+    getServiceRaw.mockReset().mockResolvedValue(undefined);
+    getServicePoliciesRaw.mockResolvedValue([]);
+
+    const actual = await engine.validate(
+      userId,
+      organisationId,
+      serviceId,
+      [],
+      correlationId,
+    );
+
+    expect(actual).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Problem

Application Insights logs showed recurring errors on the `GET /approvals/{orgId}/users/associate-services` route:
Cannot read properties of undefined (reading 'relyingParty')

The crash originated in `getAndWrapConstraintsForService` in `lib/index.js`. When `getServiceRaw` is called for a service and the applications API returns a 404, the response is `undefined`. The code then immediately accessed `service.relyingParty.params` without any null guard, causing an unhandled `TypeError` that surfaced as an error page for the user.

## Fix

Added a null guard immediately after the `getServiceRaw` call. If the service cannot be found, the function now returns an empty constraints object (no minimum, maximum, or parent/child constraints applied) and continues gracefully rather than throwing.

Also tightened the subsequent `serviceParams` access from `service.relyingParty.params ? ... : {}` to `service.relyingParty?.params ?? {}` to safely handle cases where `relyingParty` itself is undefined.

## Tests

Two new test cases added:
- `PolicyEngine.validate` - verifies no exception is thrown and an empty validation result is returned when `getServiceRaw` returns `undefined`
- `PolicyEngine.getPolicyApplicationResultsForUser` - verifies the service is treated as unconstrained (all roles available, `serviceAvailableToUser: true`) when `getServiceRaw` returns `undefined`
